### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/publications.Rmd
+++ b/publications.Rmd
@@ -38,7 +38,7 @@ year <- data.frame(subset(pubs_citations, year==y,drop = TRUE))
 cat(paste('##',y,sep=''))
 cat('\n\n')
 for (i in 1:length(year$title)){
-publications <- paste(sep='','[',year$title,']','(http://dx.doi.org/',year$doi,')',' ',year$author,'. *',year$journal,'*') # ,' Citations:',pubs_citations$cites)
+publications <- paste(sep='','[',year$title,']','(https://doi.org/',year$doi,')',' ',year$author,'. *',year$journal,'*') # ,' Citations:',pubs_citations$cites)
 cat(publications[i])
 if (!is.na(year$preprint)){
   cat(paste(sep='',' [preprint]','(',year$preprint[i],')'))
@@ -63,7 +63,7 @@ correct_author <- function(author_list,highlighted_author){
 add_doi_links <- function(description,doi){
   # Add links doi link to a field
   if (!is.na(doi)){
-    paste(sep='','[',description,']','(http://dx.doi.org/',doi,')') 
+    paste(sep='','[',description,']','(https://doi.org/',doi,')') 
   }
   else{NA}
 }

--- a/publications.bib
+++ b/publications.bib
@@ -35,7 +35,7 @@
   year={2017},
   doi = {10.1111/mec.13974},
   no={4},
-  preprint={http://dx.doi.org/10.1101/025866}
+  preprint={https://doi.org/10.1101/025866}
 }
 
 @article{crossing2016amaranth,
@@ -47,7 +47,7 @@
   publisher={Frontiers Media SA},
   doi = {10.3389/fpls.2016.00816},
   no={3},
-  preprint={http://dx.doi.org/10.7287/peerj.preprints.1951v1}
+  preprint={https://doi.org/10.7287/peerj.preprints.1951v1}
 
 }
 
@@ -61,7 +61,7 @@
   publisher={PeerJ Inc.},
   doi = {10.7717/peerj.2891},
   no={5},
-  preprint={http://dx.doi.org/10.7287/peerj.preprints.2267v1}
+  preprint={https://doi.org/10.7287/peerj.preprints.2267v1}
 }
 
 @article{phylogeny2017amaranthus,
@@ -72,7 +72,7 @@
   publisher={Academic Press},
   doi = {10.1016/j.ympev.2016.12.029},
   no={6},
-  preprint={http://dx.doi.org/10.1101/085472}
+  preprint={https://doi.org/10.1101/085472}
 }
 
 @article{review2017domestication,
@@ -92,7 +92,7 @@ author = {Mei, Wenbin and Stetter, Markus G and Gates, Daniel J. and Stitzer, Mi
 title = {Adaptation in plant genomes: Bigger is different},
 journal = {American Journal of Botany},
 issn = {1537-2197},
-url = {http://dx.doi.org/10.1002/ajb2.1002},
+url = {https://doi.org/10.1002/ajb2.1002},
 doi = {10.1002/ajb2.1002},
 pages = {n/a--n/a},
 year={2018},

--- a/publications.html
+++ b/publications.html
@@ -336,36 +336,36 @@ $(document).ready(function () {
 <div id="preprint" class="section level2">
 <h2>Preprint</h2>
 <ul>
-<li><a href="http://dx.doi.org/10.1101/313247">Genetic architecture and selective sweeps after polygenic adaptation to distant trait optima</a> <strong>Markus G Stetter</strong>, Kevin Thornton and Jeffrey Ross-Ibarra <em>bioRxiv</em></li>
+<li><a href="https://doi.org/10.1101/313247">Genetic architecture and selective sweeps after polygenic adaptation to distant trait optima</a> <strong>Markus G Stetter</strong>, Kevin Thornton and Jeffrey Ross-Ibarra <em>bioRxiv</em></li>
 </ul>
 </div>
 <div id="section" class="section level2">
 <h2>2018</h2>
 <ul>
-<li><p><a href="http://dx.doi.org/10.1007/s00122-018-3138-y">From Zero to Hero: The past, present and future of grain amaranth breeding</a> Dinesh C Joshi, Salej Sood, Rajashekara H, Lakshmi Kant, A Pattanayak, Anil Kumar, Dinesh Yadav and <strong>Markus G Stetter</strong> <em>Theoretical and Applied Genetics</em> <a href="articles/Joshi2018.pdf">Preprint</a></p></li>
-<li><p><a href="http://dx.doi.org/10.1002/ajb2.1002">Adaptation in plant genomes: Bigger is different</a> Wenbin Mei, <strong>Markus G Stetter</strong>, Daniel J. Gates, Michelle C. Stitzer and Jeffrey Ross-Ibarra <em>American Journal of Botany</em> <a href="https://www.biorxiv.org/content/early/2017/10/10/196501">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.1007/s00122-018-3138-y">From Zero to Hero: The past, present and future of grain amaranth breeding</a> Dinesh C Joshi, Salej Sood, Rajashekara H, Lakshmi Kant, A Pattanayak, Anil Kumar, Dinesh Yadav and <strong>Markus G Stetter</strong> <em>Theoretical and Applied Genetics</em> <a href="articles/Joshi2018.pdf">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.1002/ajb2.1002">Adaptation in plant genomes: Bigger is different</a> Wenbin Mei, <strong>Markus G Stetter</strong>, Daniel J. Gates, Michelle C. Stitzer and Jeffrey Ross-Ibarra <em>American Journal of Botany</em> <a href="https://www.biorxiv.org/content/early/2017/10/10/196501">Preprint</a></p></li>
 </ul>
 </div>
 <div id="section-1" class="section level2">
 <h2>2017</h2>
 <ul>
-<li><p><a href="http://dx.doi.org/10.1016/j.cub.2017.06.048">How to make a domesticate</a> <strong>Markus G Stetter</strong>, Daniel J Gates, Wenbin Mei and Jeffrey Ross-Ibarra <em>Current Biology</em> <a href="10.7287/peerj.preprints.2902v1">Preprint</a></p></li>
-<li><p><a href="http://dx.doi.org/10.1016/j.ympev.2016.12.029">Analysis of phylogenetic relationships and genome size evolution of the Amaranthus genus using GBS indicates the ancestors of an ancient crop</a> <strong>Markus G Stetter</strong> and Karl J Schmid <em>Molecular Phylogenetics and Evolution</em> <a href="http://dx.doi.org/10.1101/085472">Preprint</a></p></li>
-<li><p><a href="http://dx.doi.org/10.7717/peerj.2891">Increased root hair density by loss of WRKY6 in Arabidopsis thaliana</a> <strong>Markus G Stetter</strong>, Martin Benz and Uwe Ludewig <em>PeerJ</em> <a href="http://dx.doi.org/10.7287/peerj.preprints.2267v1">Preprint</a></p></li>
-<li><p><a href="http://dx.doi.org/10.1111/mec.13974">Genomic and phenotypic evidence for an incomplete domestication of South American grain amaranth (Amaranthus caudatus)</a> <strong>Markus G Stetter</strong>, Thomas Müller and Karl J Schmid <em>Molecular Ecology</em> <a href="http://dx.doi.org/10.1101/025866">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.1016/j.cub.2017.06.048">How to make a domesticate</a> <strong>Markus G Stetter</strong>, Daniel J Gates, Wenbin Mei and Jeffrey Ross-Ibarra <em>Current Biology</em> <a href="10.7287/peerj.preprints.2902v1">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.1016/j.ympev.2016.12.029">Analysis of phylogenetic relationships and genome size evolution of the Amaranthus genus using GBS indicates the ancestors of an ancient crop</a> <strong>Markus G Stetter</strong> and Karl J Schmid <em>Molecular Phylogenetics and Evolution</em> <a href="https://doi.org/10.1101/085472">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.7717/peerj.2891">Increased root hair density by loss of WRKY6 in Arabidopsis thaliana</a> <strong>Markus G Stetter</strong>, Martin Benz and Uwe Ludewig <em>PeerJ</em> <a href="https://doi.org/10.7287/peerj.preprints.2267v1">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.1111/mec.13974">Genomic and phenotypic evidence for an incomplete domestication of South American grain amaranth (Amaranthus caudatus)</a> <strong>Markus G Stetter</strong>, Thomas Müller and Karl J Schmid <em>Molecular Ecology</em> <a href="https://doi.org/10.1101/025866">Preprint</a></p></li>
 </ul>
 </div>
 <div id="section-2" class="section level2">
 <h2>2016</h2>
 <ul>
-<li><a href="http://dx.doi.org/10.3389/fpls.2016.00816">Crossing methods and cultivation conditions for rapid production of segregating populations in three grain amaranth species</a> <strong>Markus G Stetter</strong>, Leo Zeitler, Adrian Steinhaus, Karoline Kroener, Michelle Biljecki and Karl J Schmid <em>Frontiers in Plant Science</em> <a href="http://dx.doi.org/10.7287/peerj.preprints.1951v1">Preprint</a></li>
+<li><a href="https://doi.org/10.3389/fpls.2016.00816">Crossing methods and cultivation conditions for rapid production of segregating populations in three grain amaranth species</a> <strong>Markus G Stetter</strong>, Leo Zeitler, Adrian Steinhaus, Karoline Kroener, Michelle Biljecki and Karl J Schmid <em>Frontiers in Plant Science</em> <a href="https://doi.org/10.7287/peerj.preprints.1951v1">Preprint</a></li>
 </ul>
 </div>
 <div id="section-3" class="section level2">
 <h2>2015</h2>
 <ul>
-<li><p><a href="http://dx.doi.org/10.1007/s10265-015-0733-8">Regulation of length and density of Arabidopsis root hairs by ammonium and nitrate</a> Thomas Vatter, Benjamin Neuhäuser, <strong>Markus G Stetter</strong> and Uwe Ludewig <em>Journal of plant research</em> <a href="NA">Preprint</a></p></li>
-<li><p><a href="http://dx.doi.org/10.1371/journal.pone.0120604">Uncovering genes and ploidy involved in the high diversity in root hair density, length and response to local scarce phosphate in Arabidopsis thaliana</a> <strong>Markus G Stetter</strong>, Karl Schmid and Uwe Ludewig <em>PLOS one</em> <a href="NA">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.1007/s10265-015-0733-8">Regulation of length and density of Arabidopsis root hairs by ammonium and nitrate</a> Thomas Vatter, Benjamin Neuhäuser, <strong>Markus G Stetter</strong> and Uwe Ludewig <em>Journal of plant research</em> <a href="NA">Preprint</a></p></li>
+<li><p><a href="https://doi.org/10.1371/journal.pone.0120604">Uncovering genes and ploidy involved in the high diversity in root hair density, length and response to local scarce phosphate in Arabidopsis thaliana</a> <strong>Markus G Stetter</strong>, Karl Schmid and Uwe Ludewig <em>PLOS one</em> <a href="NA">Preprint</a></p></li>
 </ul>
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!